### PR TITLE
[Bug Fix] Redirect logged users when visiting "join community" page

### DIFF
--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -96,13 +96,25 @@ func DevelopersHandler(svr server.Server, devRepo *developer.Repository) http.Ha
 
 func SubmitDeveloperProfileHandler(svr server.Server, devRepo *developer.Repository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		svr.RenderPageForProfileRegistration(w, r, devRepo, "submit-developer-profile.html")
+		profile, _ := middleware.GetUserFromJWT(r, svr.SessionStore, svr.GetJWTSigningKey())
+		if profile != nil {
+			routeName := fmt.Sprintf("%s-Developers", strings.Title(svr.GetConfig().SiteJobCategory))
+			svr.Redirect(w, r, http.StatusMovedPermanently, fmt.Sprintf("https://%s/%s", svr.GetConfig().SiteHost, routeName))
+		} else {
+			svr.RenderPageForProfileRegistration(w, r, devRepo, "submit-developer-profile.html")
+		}
 	}
 }
 
 func SubmitRecruiterProfileHandler(svr server.Server, devRepo *developer.Repository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		svr.RenderPageForProfileRegistration(w, r, devRepo, "submit-recruiter-profile.html")
+		profile, _ := middleware.GetUserFromJWT(r, svr.SessionStore, svr.GetJWTSigningKey())
+		if profile != nil {
+			routeName := fmt.Sprintf("%s-Developers", strings.Title(svr.GetConfig().SiteJobCategory))
+			svr.Redirect(w, r, http.StatusMovedPermanently, fmt.Sprintf("https://%s/%s", svr.GetConfig().SiteHost, routeName))
+		} else {
+			svr.RenderPageForProfileRegistration(w, r, devRepo, "submit-recruiter-profile.html")
+		}
 	}
 }
 
@@ -1630,7 +1642,13 @@ func IndexPageHandler(svr server.Server, jobRepo *job.Repository) http.HandlerFu
 
 func PermanentRedirectHandler(svr server.Server, dst string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		svr.Redirect(w, r, http.StatusMovedPermanently, fmt.Sprintf("%s%s/%s", svr.GetConfig().URLProtocol, svr.GetConfig().SiteHost, dst))
+		profile, _ := middleware.GetUserFromJWT(r, svr.SessionStore, svr.GetJWTSigningKey())
+		if profile != nil && strings.EqualFold("/Join-Golang-Community", dst) {
+			routeName := fmt.Sprintf("%s-Developers", strings.Title(svr.GetConfig().SiteJobCategory))
+			svr.Redirect(w, r, http.StatusMovedPermanently, fmt.Sprintf("https://%s/%s", svr.GetConfig().SiteHost, routeName))
+		} else {
+			svr.Redirect(w, r, http.StatusMovedPermanently, fmt.Sprintf("https://%s/%s", svr.GetConfig().SiteHost, dst))
+		}
 	}
 }
 

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -100,9 +100,9 @@ func SubmitDeveloperProfileHandler(svr server.Server, devRepo *developer.Reposit
 		if profile != nil {
 			routeName := fmt.Sprintf("%s-Developers", strings.Title(svr.GetConfig().SiteJobCategory))
 			svr.Redirect(w, r, http.StatusMovedPermanently, fmt.Sprintf("https://%s/%s", svr.GetConfig().SiteHost, routeName))
-		} else {
-			svr.RenderPageForProfileRegistration(w, r, devRepo, "submit-developer-profile.html")
+			return
 		}
+		svr.RenderPageForProfileRegistration(w, r, devRepo, "submit-developer-profile.html")
 	}
 }
 
@@ -112,9 +112,9 @@ func SubmitRecruiterProfileHandler(svr server.Server, devRepo *developer.Reposit
 		if profile != nil {
 			routeName := fmt.Sprintf("%s-Developers", strings.Title(svr.GetConfig().SiteJobCategory))
 			svr.Redirect(w, r, http.StatusMovedPermanently, fmt.Sprintf("https://%s/%s", svr.GetConfig().SiteHost, routeName))
-		} else {
-			svr.RenderPageForProfileRegistration(w, r, devRepo, "submit-recruiter-profile.html")
+			return
 		}
+		svr.RenderPageForProfileRegistration(w, r, devRepo, "submit-recruiter-profile.html")
 	}
 }
 
@@ -1642,13 +1642,7 @@ func IndexPageHandler(svr server.Server, jobRepo *job.Repository) http.HandlerFu
 
 func PermanentRedirectHandler(svr server.Server, dst string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		profile, _ := middleware.GetUserFromJWT(r, svr.SessionStore, svr.GetJWTSigningKey())
-		if profile != nil && strings.EqualFold("/Join-Golang-Community", dst) {
-			routeName := fmt.Sprintf("%s-Developers", strings.Title(svr.GetConfig().SiteJobCategory))
-			svr.Redirect(w, r, http.StatusMovedPermanently, fmt.Sprintf("https://%s/%s", svr.GetConfig().SiteHost, routeName))
-		} else {
-			svr.Redirect(w, r, http.StatusMovedPermanently, fmt.Sprintf("https://%s/%s", svr.GetConfig().SiteHost, dst))
-		}
+		svr.Redirect(w, r, http.StatusMovedPermanently, fmt.Sprintf("https://%s/%s", svr.GetConfig().SiteHost, dst))
 	}
 }
 

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -99,7 +99,7 @@ func SubmitDeveloperProfileHandler(svr server.Server, devRepo *developer.Reposit
 		profile, _ := middleware.GetUserFromJWT(r, svr.SessionStore, svr.GetJWTSigningKey())
 		if profile != nil {
 			routeName := fmt.Sprintf("%s-Developers", strings.Title(svr.GetConfig().SiteJobCategory))
-			svr.Redirect(w, r, http.StatusMovedPermanently, fmt.Sprintf("https://%s/%s", svr.GetConfig().SiteHost, routeName))
+			svr.Redirect(w, r, http.StatusMovedPermanently, fmt.Sprintf("%s%s/%s", svr.GetConfig().URLProtocol, svr.GetConfig().SiteHost, routeName))
 			return
 		}
 		svr.RenderPageForProfileRegistration(w, r, devRepo, "submit-developer-profile.html")
@@ -111,7 +111,7 @@ func SubmitRecruiterProfileHandler(svr server.Server, devRepo *developer.Reposit
 		profile, _ := middleware.GetUserFromJWT(r, svr.SessionStore, svr.GetJWTSigningKey())
 		if profile != nil {
 			routeName := fmt.Sprintf("%s-Developers", strings.Title(svr.GetConfig().SiteJobCategory))
-			svr.Redirect(w, r, http.StatusMovedPermanently, fmt.Sprintf("https://%s/%s", svr.GetConfig().SiteHost, routeName))
+			svr.Redirect(w, r, http.StatusMovedPermanently, fmt.Sprintf("%s%s/%s", svr.GetConfig().URLProtocol, svr.GetConfig().SiteHost, routeName))
 			return
 		}
 		svr.RenderPageForProfileRegistration(w, r, devRepo, "submit-recruiter-profile.html")


### PR DESCRIPTION
/claim #89

Fixes #89 

@dm161 

1. Logged In users are redirected to /Golang-Developers when they visit /Join-Golang-Community or /Hire-From-Golang-Community pages
2. Added Conditional Redirect in the handlers
