### PR TITLE
[FEATURE] Show applicants on edit and manage job pages

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -270,6 +270,9 @@ func main() {
 	// @private: view edit job by token
 	svr.RegisterRoute("/edit/{token}", handler.EditJobViewPageHandler(svr, jobRepo), []string{"GET"})
 
+	// @private: download an applicants cv by applicant token
+	svr.RegisterRoute("/download-cv/{token}", handler.DownloadJobApplicationCvHandler(svr, jobRepo), []string{"GET"})
+
 	// @private: disapprove job by token
 	svr.RegisterRoute("/x/d", handler.DisapproveJobPageHandler(svr, jobRepo), []string{"POST"})
 

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -3528,6 +3528,10 @@ func ManageJobViewPageHandler(svr server.Server, jobRepo *job.Repository) http.H
 			if clickoutCount > 0 && viewCount > 0 {
 				conversionRate = fmt.Sprintf("%.2f", float64(float64(clickoutCount)/float64(viewCount)*100))
 			}
+			applicants, err := jobRepo.GetApplicantsForJob(jobID)
+			if err != nil {
+				svr.Log(err, fmt.Sprintf("unable to retrieve job applicants for job id %d", jobID))
+			}
 			svr.Render(r, w, http.StatusOK, "manage.html", map[string]interface{}{
 				"Job":                        jobPost,
 				"JobPerksEscaped":            svr.JSEscapeString(jobPost.Perks),
@@ -3537,6 +3541,7 @@ func ManageJobViewPageHandler(svr server.Server, jobRepo *job.Repository) http.H
 				"ViewCount":                  viewCount,
 				"ClickoutCount":              clickoutCount,
 				"ConversionRate":             conversionRate,
+				"Applicants":                 applicants,
 			})
 		},
 	)

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -3462,6 +3462,7 @@ func EditJobViewPageHandler(svr server.Server, jobRepo *job.Repository) http.Han
 		}
 		svr.Render(r, w, http.StatusOK, "edit.html", map[string]interface{}{
 			"Job":                        jobPost,
+			"HowToApplyIsURL":		      svr.IsEmail(jobPost.HowToApply),
 			"Stats":                      string(statsSet),
 			"Purchases":                  purchaseEvents,
 			"JobPerksEscaped":            svr.JSEscapeString(jobPost.Perks),

--- a/internal/job/model.go
+++ b/internal/job/model.go
@@ -175,6 +175,7 @@ type JobApplyURL struct {
 }
 
 type Applicant struct {
+	Token       string
 	Cv          []byte
 	Email       string
 	CreatedAt   time.Time

--- a/internal/job/model.go
+++ b/internal/job/model.go
@@ -175,6 +175,9 @@ type JobApplyURL struct {
 }
 
 type Applicant struct {
-	Cv    []byte
-	Email string
+	Cv          []byte
+	Email       string
+	CreatedAt   time.Time
+	ConfirmedAt pq.NullTime
+	CvSize      int
 }

--- a/internal/job/repository.go
+++ b/internal/job/repository.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"database/sql"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"strconv"
@@ -37,6 +38,31 @@ func (r *Repository) GetJobByApplyToken(token string) (JobPost, Applicant, error
 	}
 
 	return job, applicant, nil
+}
+
+func (r *Repository) GetApplicantsForJob(jobID int) ([]*Applicant, error) {
+	applicants := []*Applicant{}
+	var rows *sql.Rows
+	rows, err := r.db.Query(`SELECT t.cv, t.email, t.created_at, t.confirmed_at FROM apply_token t WHERE t.job_id = $1 ORDER BY t.confirmed_at ASC, t.created_at ASC`, jobID)
+	if err != nil {
+		return applicants, err
+	}
+
+	defer rows.Close()
+	for rows.Next() {
+		applicant := &Applicant{}
+		err := rows.Scan(&applicant.Cv, &applicant.Email, &applicant.CreatedAt, &applicant.ConfirmedAt)
+		if err != nil {
+			return applicants, err
+		}
+		applicant.CvSize = binary.Size(applicant.Cv)
+		applicants = append(applicants, applicant)
+	}
+	err = rows.Err()
+	if err != nil {
+		return applicants, err
+	}
+	return applicants, nil
 }
 
 func (r *Repository) TrackJobClickout(jobID int) error {

--- a/static/views/edit.html
+++ b/static/views/edit.html
@@ -356,7 +356,7 @@ body{background:#ffffff;}
             </tbody>
         </table>
     {{ else }}
-        <p>Remember, if you chose to use an external URL to collect your applications, we are unable to track applications.</p>
+        <p>{{ if .HowToApplyIsURL}}Remember, if you chose to use an external URL to collect your applications, we are unable to track applications.{{ else }}No applicants yet.{{ end }}</p>
     {{ end }}
 </article>
   {{ if .Purchases }}

--- a/static/views/edit.html
+++ b/static/views/edit.html
@@ -254,33 +254,6 @@ body{background:#ffffff;}
             {{ end }}
         </p>
     </article>
-    <article>
-        <h3>Applications for this job</h3>
-        {{ if .Applicants }}
-            <table>
-                <thead>
-                    <tr>
-                        <th>Application date</th>
-                        <th>Status</th>
-                        <th>Email address</th>
-                        <th>CV</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {{ range $i, $a := .Applicants }}
-                        <tr>
-                            <td>{{ .CreatedAt.Format "Jan 02, 2006 15:04:05 UTC" }}</td>
-                            <td>{{ if .ConfirmedAt.Valid }} Confirmed {{ .ConfirmedAt.Value.Format "Jan 02, 2006 15:04:05 UTC" }} {{ else }} Pending Confirmation {{ end }}</td>
-                            <td>{{ .Email }}</td>
-                            <td><a href="/download-cv/{{ .Token }}" target="_blank">View CV</a></td>
-                        </tr>
-                    {{ end }}
-                </tbody>
-            </table>
-        {{ else }}
-            <p>No applicants yet.</p>
-        {{ end }}
-    </article>
     <article style="margin-top: 30px;">
         <p>
             <h3>Edit your Job Ad</h3>
@@ -359,6 +332,33 @@ body{background:#ffffff;}
             {{ end }}
         </p>
   </article>
+  <article>
+    <h3>Applications for this job</h3>
+    {{ if .Applicants }}
+        <table>
+            <thead>
+                <tr>
+                    <th>Application date</th>
+                    <th>Status</th>
+                    <th>Email address</th>
+                    <th>CV</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{ range $i, $a := .Applicants }}
+                    <tr>
+                        <td>{{ .CreatedAt.Format "Jan 02, 2006 15:04:05 UTC" }}</td>
+                        <td>{{ if .ConfirmedAt.Valid }} Confirmed {{ .ConfirmedAt.Value.Format "Jan 02, 2006 15:04:05 UTC" }} {{ else }} Pending Confirmation {{ end }}</td>
+                        <td>{{ .Email }}</td>
+                        <td><a href="/download-cv/{{ .Token }}" target="_blank">View CV</a></td>
+                    </tr>
+                {{ end }}
+            </tbody>
+        </table>
+    {{ else }}
+        <p>Remember, if you chose to use an external URL to collect your applications, we are unable to track applications.</p>
+    {{ end }}
+</article>
   {{ if .Purchases }}
     <article style="margin-top: 30px;">
         <p>

--- a/static/views/edit.html
+++ b/static/views/edit.html
@@ -225,7 +225,7 @@ body{background:#ffffff;}
                         );
       }
     </script>
-    <article>
+    <article style="margin-bottom: 30px;">
         <p>
             <h3>Job Dashboard</h3>
             <small>
@@ -253,6 +253,33 @@ body{background:#ffffff;}
                 <div id="job-stats-clickouts"></div>
             {{ end }}
         </p>
+    </article>
+    <article>
+        <h3>Applications for this job</h3>
+        {{ if .Applicants }}
+            <table>
+                <thead>
+                    <tr>
+                        <th>Application date</th>
+                        <th>Status</th>
+                        <th>Email address</th>
+                        <th>CV</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{ range $i, $a := .Applicants }}
+                        <tr>
+                            <td>{{ .CreatedAt.Format "Jan 02, 2006 15:04:05 UTC" }}</td>
+                            <td>{{ if .ConfirmedAt.Valid }} Confirmed {{ .ConfirmedAt.Value.Format "Jan 02, 2006 15:04:05 UTC" }} {{ else }} Pending Confirmation {{ end }}</td>
+                            <td>{{ .Email }}</td>
+                            <td><a href="/download-cv/{{ .Token }}" target="_blank">View CV</a></td>
+                        </tr>
+                    {{ end }}
+                </tbody>
+            </table>
+        {{ else }}
+            <p>No applicants yet.</p>
+        {{ end }}
     </article>
     <article style="margin-top: 30px;">
         <p>

--- a/static/views/manage.html
+++ b/static/views/manage.html
@@ -48,8 +48,8 @@ body{background:#ffffff;}
             <div class="spinner-box"><div class="lds-ring"><div></div><div></div><div></div><div></div></div></div>
         </div>
   <section>
-    <article>
-        <p>
+    <article style="margin-bottom: 30px;">
+        <div>
             <h3>Manage Job Ad</h3>
             <small>
                 <b>Created:</b> {{ .Job.CreatedAt.Format "Jan 02, 2006 15:04:05 UTC" }}<br>
@@ -142,8 +142,34 @@ body{background:#ffffff;}
                 <input type="submit" id="approve" value="Approve" onclick="approve();" style="float: right;">
             {{ end }}
             <input type="submit" id="delete" value="Permanently Delete" onclick="permanentlyDelete();" style="float: right;background-color: rgb(211, 63, 53);">
-        </p>
-  </article>
+            <div style="clear: both"></div>
+        </div>
+    </article>
+    {{ if .Applicants }}
+        <article>
+            <h3>Applications for this job</h3>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Application date</th>
+                        <th>Status</th>
+                        <th>Email address</th>
+                        <th>CV</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{ range $i, $a := .Applicants }}
+                        <tr>
+                            <td>{{ .CreatedAt.Format "Jan 02, 2006 15:04:05 UTC" }}</td>
+                            <td>{{ if .ConfirmedAt.Valid }} Confirmed {{ .ConfirmedAt.Value.Format "Jan 02, 2006 15:04:05 UTC" }} {{ else }} Pending Confirmation {{ end }}</td>
+                            <td>{{ .Email }}</td>
+                            <td>{{ .CvSize }} bytes</td>
+                        </tr>
+                    {{ end }}
+                </tbody>
+            </table>
+        </article>
+    {{ end }}
   </section>
 		<footer>
 			<nav>

--- a/static/views/manage.html
+++ b/static/views/manage.html
@@ -163,7 +163,7 @@ body{background:#ffffff;}
                             <td>{{ .CreatedAt.Format "Jan 02, 2006 15:04:05 UTC" }}</td>
                             <td>{{ if .ConfirmedAt.Valid }} Confirmed {{ .ConfirmedAt.Value.Format "Jan 02, 2006 15:04:05 UTC" }} {{ else }} Pending Confirmation {{ end }}</td>
                             <td>{{ .Email }}</td>
-                            <td>{{ .CvSize }} bytes</td>
+                            <td><a href="/download-cv/{{ .Token }}" target="_blank">View CV</a></td>
                         </tr>
                     {{ end }}
                 </tbody>


### PR DESCRIPTION
As requested in #110

Applicants table on the edit page:

![Screenshot 2023-04-25 at 18 31 36](https://user-images.githubusercontent.com/602850/234356633-8642562e-a841-474e-82ff-2997106abb19.png)

And on the manage page:

![Screenshot 2023-04-25 at 18 31 50](https://user-images.githubusercontent.com/602850/234356644-4624e729-aa98-4e06-83ad-ff4e7983db85.png)

Some questions I have for this, which might lead to changes in the PR:

1. Are we happy showing the email address & CV link for unconfirmed applicants?
2. Are we happy with the styling, layout, and content of the table?
3. I notice the edit page does not have authentication, it relies on the obscurity of the job token. In order to serve CV PDFs, I've had to remove access control from the download endpoint and rely on the obscurity of`apply_token.token`. Are we happy managing access like that for the CV files?


Bounty hunting: /claim #110