### PR TITLE
[FEATURE] allow recruiters to search by experience level, rate, work preference

### DIFF
--- a/internal/developer/filters.go
+++ b/internal/developer/filters.go
@@ -1,0 +1,48 @@
+package developer
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type RecruiterFilters = struct {
+	HourlyMin  int
+	HourlyMax  int
+	RoleLevels map[string]interface{}
+	RoleTypes  map[string]interface{}
+}
+
+func ParseRecruiterFiltersFromQuery(query url.Values) RecruiterFilters {
+	hourlyMinStr := query.Get("hourlyMin")
+	hourlyMaxStr := query.Get("hourlyMax")
+	rawRoleLevelsStr := query.Get("roleLevel")
+	rawRoleTypesStr := query.Get("roleType")
+
+	// If we can't convert the string to an int we're happy leaving the zero values
+	hourlyMin, _ := strconv.Atoi(hourlyMinStr)
+	hourlyMax, _ := strconv.Atoi(hourlyMaxStr)
+
+	// We can take a CSV of role levels.
+	roleLevels := make(map[string]interface{})
+	for _, rawRoleLevel := range strings.Split(rawRoleLevelsStr, ",") {
+		if _, ok := ValidRoleLevels[rawRoleLevel]; ok {
+			roleLevels[rawRoleLevel] = true
+		}
+	}
+
+	// and role types
+	roleTypes := make(map[string]interface{})
+	for _, rawRoleType := range strings.Split(rawRoleTypesStr, ",") {
+		if _, ok := ValidRoleTypes[rawRoleType]; ok {
+			roleTypes[rawRoleType] = true
+		}
+	}
+
+	return RecruiterFilters{
+		hourlyMin,
+		hourlyMax,
+		roleLevels,
+		roleTypes,
+	}
+}

--- a/internal/developer/model.go
+++ b/internal/developer/model.go
@@ -1,6 +1,7 @@
 package developer
 
 import (
+	"sort"
 	"strings"
 	"time"
 )
@@ -17,19 +18,51 @@ var ValidSearchStatus = map[string]struct{}{
 	SearchStatusNotAvailable:     {},
 }
 
-var ValidRoleLevels = map[string]struct{}{
-	"junior":    {},
-	"mid-level": {},
-	"senior":    {},
-	"lead":      {},
-	"c-level":   {},
+type RoleLevel struct {
+	Id           string
+	Label        string
+	DisplayOrder int
 }
 
-var ValidRoleTypes = map[string]struct{}{
-	"full-time":  {},
-	"part-time":  {},
-	"contract":   {},
-	"internship": {},
+var ValidRoleLevels = map[string]RoleLevel{
+	"junior":    {"junior", "Junior", 0},
+	"mid-level": {"mid-level", "Mid-Level", 1},
+	"senior":    {"senior", "Senior", 2},
+	"lead":      {"lead", "Lead/Staff Engineer", 3},
+	"c-level":   {"c-level", "C-level", 4},
+}
+
+func SortedRoleLevels() (sortedRoleLevels []RoleLevel) {
+	for _, role := range ValidRoleLevels {
+		sortedRoleLevels = append(sortedRoleLevels, role)
+	}
+	sort.Slice(sortedRoleLevels, func(i, j int) bool {
+		return sortedRoleLevels[i].DisplayOrder < sortedRoleLevels[j].DisplayOrder
+	})
+	return
+}
+
+type RoleType struct {
+	Id           string
+	Label        string
+	DisplayOrder int
+}
+
+var ValidRoleTypes = map[string]RoleType{
+	"full-time":  {"full-time", "Full-Time", 0},
+	"part-time":  {"part-time", "Part-Time", 1},
+	"contract":   {"contract", "Contract", 2},
+	"internship": {"internship", "Internship", 3},
+}
+
+func SortedRoleTypes() (sortedRoleTypes []RoleType) {
+	for _, role := range ValidRoleTypes {
+		sortedRoleTypes = append(sortedRoleTypes, role)
+	}
+	sort.Slice(sortedRoleTypes, func(i, j int) bool {
+		return sortedRoleTypes[i].DisplayOrder < sortedRoleTypes[j].DisplayOrder
+	})
+	return
 }
 
 type Developer struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -651,6 +651,9 @@ func (s Server) RenderPageForDevelopers(w http.ResponseWriter, r *http.Request, 
 	if strings.EqualFold(location, "remote") {
 		locSearch = ""
 	}
+
+	recruiterFilters := developer.ParseRecruiterFiltersFromQuery(r.URL.Query())
+
 	developersForPage, totalDevelopersCount, err := devRepo.DevelopersByLocationAndTag(locSearch, tag, pageID, s.cfg.DevelopersPerPage)
 	if err != nil {
 		s.Log(err, "unable to get developers by location and tag")
@@ -726,6 +729,9 @@ func (s Server) RenderPageForDevelopers(w http.ResponseWriter, r *http.Request, 
 		s.Log(err, "GetDeveloperProfilePageViewsLastMonth")
 	}
 
+	developerRoleLevels := developer.SortedRoleLevels()
+	developerRoleTypes := developer.SortedRoleTypes()
+
 	s.Render(r, w, http.StatusOK, htmlView, map[string]interface{}{
 		"Developers":                         developersForPage,
 		"TopDeveloperSkills":                 textifyGeneric(topDeveloperSkills),
@@ -754,6 +760,9 @@ func (s Server) RenderPageForDevelopers(w http.ResponseWriter, r *http.Request, 
 		"DeveloperProfilePageViewsLastMonth": devPageViewsLastMonth,
 		"LastDevCreatedAt":                   lastDevUpdatedAt.Format(time.RFC3339),
 		"LastDevCreatedAtHumanized":          humanize.Time(lastDevUpdatedAt),
+		"DeveloperRoleLevels":                developerRoleLevels,
+		"DeveloperRoleTypes":                 developerRoleTypes,
+		"RecruiterFilters":                   recruiterFilters,
 	})
 
 }

--- a/static/views/developers.html
+++ b/static/views/developers.html
@@ -29,7 +29,62 @@ body{background:#ffffff;}
     input,textarea,select,button,option,html,body{font-family:Helvetica;font-size:18px;font-stretch:normal;font-style:normal;font-weight:400;line-height:29.7px}input,textarea,select,button,option,html,body{font-family:Helvetica;font-size:18px;font-stretch:normal;font-style:normal;font-weight:400;line-height:29.7px}th{font-weight:600}td,th{border-bottom:1.08px solid #595959;overflow:auto;padding:14.85px 18px;text-align:left;vertical-align:top}thead th{border-bottom-width:2.16px;padding-bottom:6.3px}table{display:table;overflow-x:auto}input,textarea,select,button,option,html,body{font-family:Helvetica;font-size:18px;font-stretch:normal;font-style:normal;font-weight:400;line-height:29.7px}fieldset{display:flex;flex-direction:row;flex-wrap:wrap}fieldset legend{margin:18px 0}input,textarea,select,button{border-radius:3.6px;display:inline-block;padding:9.9px}input+label,input+input[type="checkbox"],input+input[type="radio"],textarea+label,textarea+input[type="checkbox"],textarea+input[type="radio"],select+label,select+input[type="checkbox"],select+input[type="radio"],button+label,button+input[type="checkbox"],button+input[type="radio"]{page-break-before:always}input,select,label{margin-right:3.6px}textarea{min-height:90px;min-width:360px}label{display:inline-block;margin-bottom:12.6px}label+*{page-break-before:always}label>input{margin-bottom:0}input[type="submit"],input[type="reset"],button{background:#f2f2f2;color:#191919;cursor:pointer;display:inline;margin-bottom:18px;margin-right:7.2px;padding:6.525px 23.4px;text-align:center}input[type="submit"]:hover,input[type="reset"]:hover,button:hover{background:#d9d9d9;color:#000}input[type="submit"][disabled],input[type="reset"][disabled],button[disabled]{background:#e6e5e5;color:#403f3f;cursor:not-allowed}input[type="submit"],button[type="submit"]{background:{{ .PrimaryColor }};color:#fff}input[type="submit"]:hover,button[type="submit"]:hover{background:{{ .SecondaryColor }};color:#ffffff}input,select,textarea{margin-bottom:18px}input[type="text"],input[type="password"],input[type="email"],input[type="url"],input[type="phone"],input[type="tel"],input[type="number"],input[type="datetime"],input[type="date"],input[type="month"],input[type="week"],input[type="color"],input[type="time"],input[type="search"],input[type="range"],input[type="file"],input[type="datetime-local"],select,textarea{border:1px solid #595959;padding:5.4px 6.3px}input[type="checkbox"],input[type="radio"]{flex-grow:0;height:29.7px;margin-left:0;margin-right:9px;vertical-align:middle}input[type="checkbox"]+label,input[type="radio"]+label{page-break-before:avoid}select[multiple]{min-width:270px}input,textarea,select,button,option,html,body{font-family:Helvetica;font-size:18px;font-stretch:normal;font-style:normal;font-weight:400;line-height:29.7px}pre,code,kbd,samp,var,output{font-family:Menlo,Monaco,Consolas,"Courier New",monospace;font-size:14.4px}pre{border-left:1.8px solid #59c072;line-height:25.2px;overflow:auto;padding-left:18px}pre code{background:none;border:0;line-height:29.7px;padding:0}code,kbd{background:#daf1e0;border-radius:3.6px;color:#2a6f3b;display:inline-block;line-height:18px;padding:3.6px 6.3px 2.7px}kbd{background:#2a6f3b;color:#fff}mark{background:#ffc;padding:0 3.6px}input,textarea,select,button,option,html,body{font-family:Helvetica;font-size:18px;font-stretch:normal;font-style:normal;font-weight:400;line-height:29.7px}h1,h2,h3,h4,h5,h6{color:#000;margin-bottom:18px}h1{font-size:36px;font-weight:500;line-height:41.4px;margin-top:72px}h2{font-size:25.2px;font-weight:400;line-height:30.6px;margin-top:54px}h3{font-size:21.6px;line-height:27px;margin-top:36px}h4{font-size:18px;line-height:23.4px;margin-top:18px}h5{font-size:14.4px;font-weight:bold;line-height:21.6px;text-transform:uppercase}h6{color:#595959;font-size:14.4px;font-weight:bold;line-height:18px;text-transform:uppercase}input,textarea,select,button,option,html,body{font-family:Helvetica;font-size:18px;font-stretch:normal;font-style:normal;font-weight:400;line-height:29.7px}a{color:{{ .PrimaryColor }};text-decoration:none}a:hover{text-decoration:underline}hr{border-bottom:1px solid #595959}figcaption,small{font-size:15.3px}figcaption{color:#595959}var,em,i{font-style:italic}dt,strong,b{font-weight:600}del,s{text-decoration:line-through}ins,u{text-decoration:underline}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sup{top:-.5em}sub{bottom:-.25em}*{border:0;border-collapse:separate;border-spacing:0;box-sizing:border-box;margin:0;max-width:100%;outline:0;padding:0;vertical-align:baseline}html,body{width:100%}html{height:100%}body{color:#1a1919;}p,ul,ol,dl,blockquote,hr,pre,table,form,fieldset,figure,address{margin-bottom:29.7px}section{margin-left:auto;margin-right:auto;width:780px}article,header,footer{padding:43.2px}article{word-wrap: break-word;background:#fff;border:1px solid #d9d9d9;border-radius:7.2px}nav{text-align:center}nav ul{list-style:none;margin-left:0;text-align:center}nav ul li{display:inline-block;margin-left:9px;margin-right:9px;vertical-align:middle}nav ul li:last-child{margin-right:0}ol,ul{margin-left:31.5px}li dl,li ol,li ul{margin-bottom:0}dl{display:inline-block}dt{padding:0 18px}dd{padding:0 18px 4.5px}dd:last-of-type{border-bottom:1.08px solid #595959}dd+dt{border-top:1.08px solid #595959;padding-top:9px}blockquote{border-left:2.16px solid #595959;padding:4.5px 18px 4.5px 15.84px}blockquote footer{color:#595959;font-size:13.5px;margin:0}blockquote p{margin-bottom:0}img{height:auto;margin:0 auto}figure img{display:block}/*# sourceMappingURL=tacit-css-1.3.2.min.css.map */
     footer{padding:10px;width:780px;margin:auto;}.subnav{width: 100%;text-align: left;float: left;font-size: 12pt;}.subnav ul {text-align:left;}.subnav ul li {width:90%;}
     .mobile-only { display: none; }
-    #search-location,#search-tag{margin-bottom:1px;border:1px solid #d9d9d9;width:100%;}#search-location-container,#search-tag-container{position:relative;width:35%;display:inline-block;}.search-suggestions{z-index:1;width:100%;border:1px solid #d9d9d9;position:absolute;background:#fff;border-radius: 0 0 3.6px 3.6px;border-top: 0px;margin-top: -2px;}.search-option{padding:5px 10px;}.search-option:hover{background:#d9d9d9;cursor:pointer;}#search-btn{width:25%;margin-right:0;float:right;padding:5.53px 10px;border:1px solid {{ .PrimaryColor }};}#post-btn{width:auto;float:right;margin-right:0;padding-right:25px;padding-left: 25px;}
+    #search-location,
+    #search-tag{
+        margin-bottom:1px;
+        border:1px solid #d9d9d9;
+        width:100%;
+    }
+    #search-location-container,
+    #search-tag-container {
+        position:relative;
+    }
+    .search-suggestions {
+        z-index:1;
+        width:100%;
+        border:1px solid #d9d9d9;
+        position:absolute;
+        background:#fff;
+        border-radius: 0 0 3.6px 3.6px;
+        border-top: 0px;
+        margin-top: -2px;
+    }
+    .search-option {
+        padding:5px 10px;
+    }
+    .search-option:hover {
+        background:#d9d9d9;
+        cursor:pointer;
+    }
+    .field-group {
+        display: flex;
+        flex-direction: column;
+        margin-right: 20px;
+    }
+    .checkbox-list-item {
+        display: flex;
+        width: 100%;
+        align-items: center;
+    }
+    .checkbox-list-item input[type="checkbox"] {
+        height: initial;
+        margin-bottom: 0;
+    }
+    .checkbox-list-item label {
+        margin: 0;
+    }
+    #search-btn {
+        width:25%;
+        padding:5.53px 10px;
+        border:1px solid {{ .PrimaryColor }};
+    }
+    #post-btn {
+        width:auto;
+        float:right;
+        margin-right:0;
+        padding-right:25px;
+        padding-left: 25px;
+    }
     @media only screen and (max-width:768px){
         .subnav{width: 100%;}
         #search-location-container,#search-tag-container{width:100%;}
@@ -84,21 +139,66 @@ body{background:#ffffff;}
 	<h1 class="main-title">{{ .SiteJobCategory }} {{ if .TagFilter }}{{ .TagFilter }} {{ end }}Developers {{ if .LocationFilter }}in {{ .LocationFilter }}{{ end }} </h1><br>
 	<h2 style="font-size:12pt;font-weight:100;margin-top:20px">Browse, view and reach <b>{{ if .TotalDevelopersCount }}{{ .TotalDevelopersCount }}{{ end }} {{ .SiteJobCategory }}{{ if .TagFilter }} {{ .TagFilter }}{{ end }} developers</b> for hire {{ if .LocationFilter }} in <b>{{ .LocationFilter }}{{ if .Region }}, {{ .Region }}{{ end }}{{ if .Country }}, {{ .Country }}{{ end }}</b>{{ end }} in {{ .MonthAndYear }}. Search developers experienced in <b>{{ .TopDeveloperSkills }}</b>. {{ .SiteJobCategory }} developers like <b>{{ .TopDeveloperNames }}</b> and many more are available for hire on {{ .SiteName }}. Last developer joined <b><time datetime="{{ .LastDevCreatedAt }}">{{ .LastDevCreatedAtHumanized }}</time></b></h2>
     <div style="margin-bottom: 10px;">
-	<div id="search-tag-container">
-        <input autocomplete="off" type="text" value="{{ .TagFilter }}" placeholder="Skills" id="search-tag">
-	<div style="z-index:1000;display:none;" id="search-tag-suggestions" class="search-suggestions">
-	</div>
-	</div>
-	<div id="search-location-container">
-        <input autocomplete="off" type="text" value="{{ .LocationFilter }}" placeholder="City, Country" id="search-location">
-	<div id="search-location-suggestions" style="display:none;" class="search-suggestions">
-	</div>
-	</div>
-        <input type="submit" value="Search" id="search-btn">
+        <div class="container" style="margin-bottom: 30px;">
+            <div id="search-tag-container">
+                <label for="search-tag">Skills</label>
+                <input autocomplete="off" type="text" value="{{ .TagFilter }}" placeholder="Skills" id="search-tag" name="search-tag">
+                <div style="z-index:1000;display:none;" id="search-tag-suggestions" class="search-suggestions"></div>
+            </div>
+            <div id="search-location-container">
+                <label for="search-location">Location</label>
+                <input autocomplete="off" type="text" value="{{ .LocationFilter }}" placeholder="City, Country" id="search-location" name="search-location">
+                <div id="search-location-suggestions" style="display:none;" class="search-suggestions"></div>
+            </div>
+        </div>
+        {{ if or .IsUserRecruiter .IsUserAdmin }}
+            <form id="recruiter-filters">
+                <fieldset class="container">
+                    <legend><strong>Recruiter filters</strong></legend>
+                    
+                    <fieldset style="grid-column: span 2; margin-bottom: 10px;">
+                        <legend>Hourly Rate</legend>
+
+                        <div class="field-group">
+                            <label for="hourlyMin">Minimum</label>
+                            <input type="number" name="hourlyMin" id="hourlyMin" value="{{ if .RecruiterFilters.HourlyMin }}{{ .RecruiterFilters.HourlyMin }}{{ end }}" placeholder="0">
+                        </div>
+
+                        <div class="field-group">
+                            <label for="hourlyMax">Maximum</label>
+                            <input type="number" name="hourlyMax" id="hourlyMax" value="{{ if .RecruiterFilters.HourlyMax }}{{ .RecruiterFilters.HourlyMax }}{{ end }}" placeholder="Unlimited">
+                        </div>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend>Experience level</legend>
+                        {{ range $v, $l := .DeveloperRoleLevels }}
+                        <div class="checkbox-list-item">
+                            <input type="checkbox" name="roleLevel" id="roleLevel[{{ .Id }}]" value="{{ .Id }}" {{ if index $.RecruiterFilters.RoleLevels .Id }}checked{{ end }} />
+                            <label for="roleLevel[{{ .Id }}]">{{ .Label }}</label>
+                        </div>
+                        {{ end }}
+                    </fieldset>
+
+                    <fieldset>
+                        <legend>Work preference</legend>
+                        {{ range $v, $l := .DeveloperRoleTypes }}
+                        <div class="checkbox-list-item">
+                            <input type="checkbox" name="roleType" id="roleType[{{ .Id }}]" value="{{ .Id }}" {{ if index $.RecruiterFilters.RoleTypes .Id }}checked{{ end }} />
+                            <label for="roleType[{{ .Id }}]">{{ .Label }}</label>
+                        </div>
+                        {{ end }}
+                    </fieldset>
+                </fieldset>
+            </form>
+        {{ end }}
+        <div>
+            <input type="submit" value="Search" id="search-btn">
+        </div>
        	<div class="mobile-only">
-	    <div style="width:100%; text-align: center;margin-top: 20px;margin-bottom: 10px;">Looking for a {{ .SiteJobCategory }} Job?</div>
-	    <input type="submit" class="mobile-only" value="Join the Community" id="post-btn-mobile" onclick="window.location.href='/Join-{{ .SiteJobCategoryURLEncoded }}-Community';">  
-	</div>
+            <div style="width:100%; text-align: center;margin-top: 20px;margin-bottom: 10px;">Looking for a {{ .SiteJobCategory }} Job?</div>
+            <input type="submit" class="mobile-only" value="Join the Community" id="post-btn-mobile" onclick="window.location.href='/Join-{{ .SiteJobCategoryURLEncoded }}-Community';">  
+        </div>
     </div>
     <div class="overlay-effect" id="overlay-0" onclick="closeApplyPopup();"></div>
     {{ if .DevelopersBannerLink }}
@@ -469,15 +569,37 @@ body{background:#ffffff;}
             showPopup();
             return;
             {{ end }}
+            let newLocation;
+            
             if (document.getElementById('search-location').value.trim() === '' && document.getElementById('search-tag').value.trim() === '') {
-				window.location.href = '/{{ .SiteJobCategoryURLEncoded }}-Developers';
+				newLocation = '/{{ .SiteJobCategoryURLEncoded }}-Developers';
             } else if (document.getElementById('search-location').value.trim() !== '' && document.getElementById('search-tag').value.trim() === '') {
-				window.location.href = '/{{ .SiteJobCategoryURLEncoded }}-Developers-In-'+encodeURIComponent(document.getElementById('search-location').value);
+				newLocation = '/{{ .SiteJobCategoryURLEncoded }}-Developers-In-'+encodeURIComponent(document.getElementById('search-location').value);
             } else if (document.getElementById('search-location').value.trim() === '' && document.getElementById('search-tag').value.trim() !== '') {
-				window.location.href = '/{{ .SiteJobCategoryURLEncoded }}-'+encodeURIComponent(document.getElementById('search-tag').value)+'-Developers';
+				newLocation = '/{{ .SiteJobCategoryURLEncoded }}-'+encodeURIComponent(document.getElementById('search-tag').value)+'-Developers';
             } else {
-				window.location.href = '/{{ .SiteJobCategoryURLEncoded }}-'+encodeURIComponent(document.getElementById('search-tag').value)+'-Developers-In-'+encodeURIComponent(document.getElementById('search-location').value);
+				newLocation = '/{{ .SiteJobCategoryURLEncoded }}-'+encodeURIComponent(document.getElementById('search-tag').value)+'-Developers-In-'+encodeURIComponent(document.getElementById('search-location').value);
             }
+
+            const recruiterFiltersForm = document.getElementById("recruiter-filters");
+            if (recruiterFiltersForm) {
+                const recruiterFiltersData = new FormData(recruiterFiltersForm);
+                const roleTypes = recruiterFiltersData.getAll('roleType');
+                const roleLevels = recruiterFiltersData.getAll('roleLevel');
+
+                // Go doesn't like repeated query params, so we'll turn them into CSVs
+                if (roleTypes.length > 0) {
+                    recruiterFiltersData.set('roleType', roleTypes.join(','));
+                }
+                
+                if (roleLevels.length > 0) {
+                    recruiterFiltersData.set('roleLevel', roleLevels.join(','));
+                }
+
+                newLocation += '?' + new URLSearchParams(recruiterFiltersData);
+            }
+
+            window.location.href = newLocation
         });
         {{ if not .LoggedUser }}
         window.addEventListener("scroll", function() {


### PR DESCRIPTION
As requested in #76 

I've added filtering to the developers page that is only available to administrators and recruiters.

![image](https://user-images.githubusercontent.com/602850/234698767-aa127f48-a8fa-41a6-9d38-7f425b5bebcd.png)

I've extended `developers/model.go` so I can reuse `ValidRoleLevels` and `ValidRoleTypes`, and I've introduced some `Sorted...` methods in there so we can control the order in which these fields render on the filters page.

When the search filters are applied, I'm taking the recruiter filters and adding them to the URL as query parameters.

The backend code only applies these filters if the logged in user is a recruiter or admin. For unauthorised users, the query parameters are ignored entirely – we don't even parse them.

To apply the filters, I've had to really change up how we were building the SQL query in `DevelopersByLocationAndTag` so we can dynamically add WHERE conditions when relevant.

This has allowed us to simplify the query in ways, as we no longer need a `switch` statement that covers every possible permutation of location, skills, and these new filters.

Annoyingly, the postgres database doesn't like `?` placeholder values and instead requires us to set `$1`, `$2`, `$3`, etc. To make it work I've had to introduce `argIndex` to keep track of how many dynamic arguments we insert, so the next placeholders are set correctly (this enables the next condition to be added as `$4`.

Of course, I'm not wedded to any particular styling or behavioural decisions. Happy to work with y'all and tweak as required :)

Bounty hunting: /claim #76