### PR TITLE
Add rate-limiting on successful signons on the RequestTokenSignOn handler

### DIFF
--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -2020,7 +2020,7 @@ func RequestTokenSignOn(svr server.Server, userRepo *user.Repository, jobRepo *j
 		}
 
 		numberOfAttempts = numberOfAttempts + 1
-		svr.CacheSet(req.Email, attemptsByte)
+		svr.CacheSet(fmt.Sprintf("sign-on-request-%s", req.Email), []byte(strconv.Itoa(numberOfAttempts)))
 
 		token := k.String()
 		err = svr.GetEmail().SendHTMLEmail(

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -2020,7 +2020,6 @@ func RequestTokenSignOn(svr server.Server, userRepo *user.Repository, jobRepo *j
 		}
 
 		numberOfAttempts = numberOfAttempts + 1
-		attemptsByte := []byte(strconv.Itoa(numberOfAttempts))
 		svr.CacheSet(req.Email, attemptsByte)
 
 		token := k.String()

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -1986,6 +1986,13 @@ func RequestTokenSignOn(svr server.Server, userRepo *user.Repository, jobRepo *j
 			svr.JSON(w, http.StatusBadRequest, nil)
 			return
 		}
+
+		attempts := svr.GetSignOnAttempts(req.Email)
+		if attempts > 5 {
+			svr.JSON(w, http.StatusTooManyRequests, "Too many requests today.")
+			return
+		}
+
 		userType, err := userRepo.GetUserTypeByEmailOrCreateUserIfRecruiter(req.Email, jobRepo, recRepo)
 		if err != nil {
 			svr.JSON(w, http.StatusNotFound, nil)
@@ -2003,6 +2010,8 @@ func RequestTokenSignOn(svr server.Server, userRepo *user.Repository, jobRepo *j
 			svr.JSON(w, http.StatusBadRequest, nil)
 			return
 		}
+		svr.SaveSignOnAttempts(req.Email)
+
 		token := k.String()
 		err = svr.GetEmail().SendHTMLEmail(
 			email.Address{Name: svr.GetEmail().DefaultSenderName(), Email: svr.GetEmail().NoReplySenderAddress()},

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -1988,7 +1988,7 @@ func RequestTokenSignOn(svr server.Server, userRepo *user.Repository, jobRepo *j
 		}
 
 		numberOfAttempts := 0
-		cachedAttempts, found := svr.CacheGet(req.Email)
+		cachedAttempts, found := svr.CacheGet(fmt.Sprintf("sign-on-request-%s", req.Email))
 		if found {
 			attempts, err := strconv.Atoi(string(cachedAttempts))
 			if err == nil {

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -1988,7 +1988,7 @@ func RequestTokenSignOn(svr server.Server, userRepo *user.Repository, jobRepo *j
 		}
 
 		attempts := svr.GetSignOnAttempts(req.Email)
-		if attempts > 5 {
+		if attempts >= 5 {
 			svr.JSON(w, http.StatusTooManyRequests, "Too many requests today.")
 			return
 		}

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -1988,9 +1988,9 @@ func RequestTokenSignOn(svr server.Server, userRepo *user.Repository, jobRepo *j
 		}
 
 		numberOfAttempts := 0
-		attempts, found := svr.CacheGet(req.Email)
+		cachedAttempts, found := svr.CacheGet(req.Email)
 		if found {
-			attempts, err := strconv.Atoi(string(attempts))
+			attempts, err := strconv.Atoi(string(cachedAttempts))
 			if err == nil {
 				numberOfAttempts = attempts
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1234,24 +1234,3 @@ func (s Server) SeenSince(r *http.Request, timeAgo time.Duration) bool {
 func (s Server) IsEmail(val string) bool {
 	return s.emailRe.MatchString(val)
 }
-
-func (s Server) GetSignOnAttempts(email string) int {
-	numberOfAttempts := 0
-	attempts, found := s.CacheGet(email)
-	if found {
-		numberOfAttempts, err := strconv.Atoi(string(attempts))
-		if err == nil {
-			return numberOfAttempts
-		}
-	}
-
-	return numberOfAttempts
-}
-
-func (s Server) SaveSignOnAttempts(email string) {
-	numberOfAttempts := s.GetSignOnAttempts(email)
-	numberOfAttempts = numberOfAttempts + 1
-
-	attemptsByte := []byte(strconv.Itoa(numberOfAttempts))
-	s.CacheSet(email, attemptsByte)
-}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -512,7 +512,7 @@ func (s Server) RenderPageForLocationAndTag(w http.ResponseWriter, r *http.Reque
 		"CurrentPage":                        pageID,
 		"ShowPage":                           showPage,
 		"PageSize":                           s.cfg.JobsPerPage,
-		"TopDevelopers": topDevelopers,
+		"TopDevelopers":                      topDevelopers,
 		"PageIndexes":                        pages,
 		"TotalJobCount":                      totalJobCount,
 		"TextJobCount":                       textifyJobCount(totalJobCount),
@@ -1233,4 +1233,25 @@ func (s Server) SeenSince(r *http.Request, timeAgo time.Duration) bool {
 
 func (s Server) IsEmail(val string) bool {
 	return s.emailRe.MatchString(val)
+}
+
+func (s Server) GetSignOnAttempts(email string) int {
+	numberOfAttempts := 1
+	attempts, found := s.CacheGet(email)
+	if found {
+		numberOfAttempts, err := strconv.Atoi(string(attempts))
+		if err == nil {
+			return numberOfAttempts
+		}
+	}
+
+	return numberOfAttempts
+}
+
+func (s Server) SaveSignOnAttempts(email string) {
+	numberOfAttempts := s.GetSignOnAttempts(email)
+	numberOfAttempts = numberOfAttempts + 1
+
+	attemptsByte := []byte(strconv.Itoa(numberOfAttempts))
+	s.CacheSet(email, attemptsByte)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1236,7 +1236,7 @@ func (s Server) IsEmail(val string) bool {
 }
 
 func (s Server) GetSignOnAttempts(email string) int {
-	numberOfAttempts := 1
+	numberOfAttempts := 0
 	attempts, found := s.CacheGet(email)
 	if found {
 		numberOfAttempts, err := strconv.Atoi(string(attempts))

--- a/static/views/auth.html
+++ b/static/views/auth.html
@@ -846,13 +846,13 @@
                 document.getElementById("spinner-0").style.display = "none";
                 return;
             }
-            post({ email: email }, function (success) {
+            post({ email: email }, function (success, response) {
                 document.getElementById("spinner-0").style.display = "none";
                 if (success) {
                     alert("Check your inbox");
                     document.getElementById("email").value = "";
                 } else {
-                    alert('Oops, this email looks incorrect');
+                    alert(response || 'Oops, this email looks incorrect');
                 }
             });
         }

--- a/static/views/auth.html
+++ b/static/views/auth.html
@@ -834,7 +834,7 @@
             xhr.send(JSON.stringify(body));
             xhr.onreadystatechange = function () {
                 if (xhr.readyState === 4) {
-                    cb(xhr.status === 200, xhr.response);
+                    cb(xhr.status, xhr.response);
                 }
             }
         };
@@ -846,13 +846,18 @@
                 document.getElementById("spinner-0").style.display = "none";
                 return;
             }
-            post({ email: email }, function (success, response) {
+            post({ email: email }, function (status) {
                 document.getElementById("spinner-0").style.display = "none";
-                if (success) {
-                    alert("Check your inbox");
-                    document.getElementById("email").value = "";
-                } else {
-                    alert(response || 'Oops, this email looks incorrect');
+                switch(status) {
+                    case 200:
+                        alert("Check your inbox");
+                        document.getElementById("email").value = "";
+                        break;
+                    case 429:
+                        alert("Please try again later, you sent too many login requests")
+                        break;
+                    default:
+                        alert('Oops, this email looks incorrect');
                 }
             });
         }


### PR DESCRIPTION
Add rate limiting on successful sign-ons

### BigCache global eviction window

The global eviction window is 12 hours
There was no way to set a 24 hour window on 
a bigCache key so I set the limit at 5 requests/12 hour window.

/fixes #116
/claim #116